### PR TITLE
feat: view more/view less in job description

### DIFF
--- a/packages/web-client/src/components/application_jd.tsx
+++ b/packages/web-client/src/components/application_jd.tsx
@@ -12,6 +12,7 @@ export default function ApplicationJobDescription(props: Props) {
   const [jd, setJd] = useState(application.job_description);
   const [mode, setMode] = useState<'view' | 'edit'>('view');
   const [isBusy, setIsBusy] = useState(false);
+  const [isFullJDShown, setIsFullJDShown] = useState(false);
 
   async function patchJD() {
     setIsBusy(true);
@@ -32,8 +33,12 @@ export default function ApplicationJobDescription(props: Props) {
   if (mode === 'view') {
     return (
       <div>
-        <button className="btn compact gray" onClick={() => setMode('edit')}>Edit</button>
-        <div className="formatted-html" dangerouslySetInnerHTML={{ __html: renderMD(jd) }} />
+        <div className="space-x-2"> 
+          <button className="btn compact gray" onClick={() => setMode('edit')}>Edit</button>
+          <button className="btn compact" onClick={() => setIsFullJDShown(prev => !prev)}>{isFullJDShown ? 'View less' : "View more"}</button>
+        </div>
+
+        <div className="formatted-html" dangerouslySetInnerHTML={{ __html: renderMD(isFullJDShown ? jd : `${jd.slice(0, 200)}...`) }} />
       </div>
     )
   }


### PR DESCRIPTION
Closes #8. Introduced **view less/view more** feature for the job description.

Before:
<img width="1206" alt="image" src="https://github.com/user-attachments/assets/17610c1f-7df3-4aa6-b310-36f3a25cdc19" />

After:
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/5943dd54-1dd2-470c-98b2-166a96da306e" />
